### PR TITLE
Use `nba-hack` module instead of `nba` to get needed HTTP headers fix

### DIFF
--- a/apiExtensions.js
+++ b/apiExtensions.js
@@ -1,8 +1,8 @@
-var nba = require("nba");
-var ep = require("nba/lib/endpoints");
-var maps = require( "nba/lib/maps" );
-var util = require( "nba/lib/util" );
-var getJSON = require( "nba/lib/get-json" );
+var nba = require("nba-hack");
+var ep = require("nba-hack/lib/endpoints");
+var maps = require( "nba-hack/lib/maps" );
+var util = require( "nba-hack/lib/util" );
+var getJSON = require( "nba-hack/lib/get-json" );
 var _ = require('underscore');
 
 var twoWayMap = maps.twoWayMap();

--- a/controller.js
+++ b/controller.js
@@ -1,4 +1,4 @@
-var nba = require('nba');
+var nba = require('nba-hack');
 var _ = require('underscore');
 var moment = require('moment');
 var Promise = require( "es6-promise" ).Promise;

--- a/generate.js
+++ b/generate.js
@@ -1,4 +1,4 @@
-var nba = require('nba');
+var nba = require('nba-hack');
 var fs = require('fs');
 var _ = require('underscore');
 var Handlebars = require('handlebars');

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 var express = require('express');
 var app = express();
 require('./apiExtensions');
-var nba = require('nba');
+var nba = require('nba-hack');
 var controller = require('./controller');
 var Promise = require( "es6-promise" ).Promise;
 
 
 nba.ready(function() {
-    nba.api.playersInfo({season: "2014-15"}).then( function (resp) {
+    nba.api.playersInfo({season: "2015-16"}).then( function (resp) {
         nba.playersInfo = resp;
 
         app.set('port', (process.env.PORT || 5000));

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "moment": "2.8.4",
     "moment-timezone": "^0.2.5",
     "mongoose": "^4.1.10",
-    "nba": "~0.2.0",
+    "nba-hack": "0.0.3",
     "query-string": "^1.0.0",
     "sleep": "1.2.0",
     "underscore": "1.7.0"

--- a/populateDB.js
+++ b/populateDB.js
@@ -1,5 +1,5 @@
 #! /app/bin/node
-var nba = require('nba');
+var nba = require('nba-hack');
 var _ = require('underscore');
 var moment = require('moment-timezone');
 var Promise = require( "es6-promise" ).Promise;

--- a/service.js
+++ b/service.js
@@ -1,4 +1,4 @@
-var nba = require('nba');
+var nba = require('nba-hack');
 var _ = require('underscore');
 var Promise = require( "es6-promise" ).Promise;
 var dao = require('./dao');

--- a/update_games.js
+++ b/update_games.js
@@ -1,4 +1,4 @@
-var nba = require('nba');
+var nba = require('nba-hack');
 var _ = require('underscore');
 var moment = require('moment-timezone');
 var Promise = require( "es6-promise" ).Promise;


### PR DESCRIPTION
The stats generator recently stopped working due to a change to stats.nba.com which required some HTTP headers in order to work. Since we're currently stuck on an old version (0.2.0) of nba and I don't have time to finish the upgrade to 2.0.0, I forked version 0.2.0 and cherry picked the fix for this issue. Don't judge me, I've got a life to lead!

Eventually I'll take the time to give this repo some love and get it moved up to the latest version of nba. But not today.
